### PR TITLE
LDS-3395 - ProductExternalSyncFailed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'fr.lecomptoirdespharmacies'
-version '0.2.8'
+version '0.2.9'
 
 apply plugin: 'java'
 apply plugin: 'maven'
@@ -32,7 +32,7 @@ uploadArchives {
     repositories.mavenDeployer {
         pom.groupId = 'fr.lecomptoirdespharmacies'
         pom.artifactId = 'vidal-java-sdk'
-        pom.version = '0.2.8'
+        pom.version = '0.2.9'
         configuration = configurations.deployerJars
         repository(url: "git:releases://git@bitbucket.org:lecomptoirdespharmacies/maven_repository.git")
         snapshotRepository(url: "git:snapshots://git@bitbucket.org:lecomptoirdespharmacies/maven_repository.git")

--- a/src/main/java/fr/lecomptoirdespharmacies/core/apis/PackageApi.java
+++ b/src/main/java/fr/lecomptoirdespharmacies/core/apis/PackageApi.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.net.URLEncoder;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static fr.lecomptoirdespharmacies.core.Constant.AGGREGATE_LIST;
@@ -117,6 +118,8 @@ public class PackageApi extends BaseApi {
                     } catch (Exception ex){
                         throw new RuntimeException(ex);
                     }
-                }).collect(Collectors.toList());
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Pour une raison inconnue, la méthode `get(e.vidalId)` peut renvoyer `null`. On va filtrer les valeurs nulles avant de renvoyer la liste aux consommateurs de l'API