### PR TITLE
LDS-3428 NullPointerException: Cannot invoke "java.util.List.size()" …

### DIFF
--- a/src/main/java/fr/lecomptoirdespharmacies/core/apis/PackageApi.java
+++ b/src/main/java/fr/lecomptoirdespharmacies/core/apis/PackageApi.java
@@ -10,7 +10,6 @@ import fr.lecomptoirdespharmacies.entities.Package;
 import org.apache.commons.lang3.StringUtils;
 
 import java.net.URLEncoder;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/fr/lecomptoirdespharmacies/core/apis/PackageApi.java
+++ b/src/main/java/fr/lecomptoirdespharmacies/core/apis/PackageApi.java
@@ -10,6 +10,8 @@ import fr.lecomptoirdespharmacies.entities.Package;
 import org.apache.commons.lang3.StringUtils;
 
 import java.net.URLEncoder;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -111,6 +113,10 @@ public class PackageApi extends BaseApi {
      * @return          Packages
      */
     private List<Package> baseToPackage(List<Base> entities){
+        if (Objects.isNull(entities)) {
+            return Collections.emptyList();
+        }
+
         return entities.stream()
                 .map(e -> {
                     try {

--- a/src/main/java/fr/lecomptoirdespharmacies/core/helpers/ListHelper.java
+++ b/src/main/java/fr/lecomptoirdespharmacies/core/helpers/ListHelper.java
@@ -2,19 +2,21 @@ package fr.lecomptoirdespharmacies.core.helpers;
 
 import fr.lecomptoirdespharmacies.entities.AbstractBase;
 
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ListHelper {
 
     public static <T extends AbstractBase>  T getObject(List<T> objects) throws Exception{
+        if(Objects.isNull(objects) || objects.isEmpty())
+            return null;
+
         if(objects.size() == 1){
             return objects.get(0);
-        } else if (objects.size() > 1) {
+        } else {
             throw new Exception("Too much element for this request.");
         }
-        return null;
     }
 
     public static List<String> mergeList(List<String> list1, List<String> list2){


### PR DESCRIPTION
java.lang.NullPointerException: Cannot invoke "java.util.List.size()" because "objects" is null

Fix de ce problème:

ForkJoinPool-5-worker-2 - ERROR - helpers.VidalHelper - Unable to retrieve package for this vidal id : 603431
java.lang.NullPointerException: Cannot invoke "java.util.List.size()" because "objects" is null
        at fr.lecomptoirdespharmacies.core.helpers.ListHelper.getObject(ListHelper.java:12)
        at fr.lecomptoirdespharmacies.core.apis.PackageApi.get(PackageApi.java:51)
        at helpers.VidalHelper.getPackage(VidalHelper.java:29)
        at helpers.ProductVidalHelper.getPackageWithId(ProductVidalHelper.java:36)
        at domain.products.synchronization.mutagenesis.factories.VidalMutagenFactory.lambda$createMutagen$3(VidalMutagenFactory.java:119)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1760)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)